### PR TITLE
Fix image rotation.

### DIFF
--- a/resources/dist/js/component.js
+++ b/resources/dist/js/component.js
@@ -78,7 +78,7 @@ document.addEventListener('alpine:init', () => {
         },
 
         rotateByValue(value){
-            const previousRotate = this.cropper.getImageData().rotate;
+            const previousRotate = this.cropper.getImageData().rotate || 0;
             this.cropper.rotate(value-previousRotate)
         },
         resetRotate(){


### PR DESCRIPTION
Rotation was not working because, when `getImageData().rotate` is undefined,  `NaN` will be passed to cropper.rotate() function